### PR TITLE
Repo reorg classloader

### DIFF
--- a/common/src/CMakeLists.txt
+++ b/common/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Add library for odin-data shared functionality
+include_directories(${Boost_INCLUDE_DIRS} ${ZEROMQ_INCLUDE_DIRS})
 
 file(GLOB LIB_SOURCES *.cpp)
 

--- a/frameReceiver/include/ExcaliburFrameDecoder.h
+++ b/frameReceiver/include/ExcaliburFrameDecoder.h
@@ -21,8 +21,10 @@ namespace FrameReceiver
     {
     public:
 
-        ExcaliburFrameDecoder(LoggerPtr& logger, bool ebable_packet_logging=false, unsigned int frame_timeout_ms=1000);
+        ExcaliburFrameDecoder();
         ~ExcaliburFrameDecoder();
+
+        void init(LoggerPtr& logger, bool ebable_packet_logging=false, unsigned int frame_timeout_ms=1000);
 
         const size_t get_frame_buffer_size(void) const;
         const size_t get_frame_header_size(void) const;
@@ -59,8 +61,6 @@ namespace FrameReceiver
 
         bool dropping_frame_data_;
 
-        unsigned int frame_timeout_ms_;
-        unsigned int frames_timedout_;
     };
 
 } // namespace FrameReceiver

--- a/frameReceiver/include/FrameDecoder.h
+++ b/frameReceiver/include/FrameDecoder.h
@@ -49,15 +49,25 @@ namespace FrameReceiver
 			FrameReceiveStateError
         };
 
-        FrameDecoder(LoggerPtr& logger, bool enable_packet_logging) :
-            logger_(logger),
-            enable_packet_logging_(enable_packet_logging)
+        FrameDecoder() :
+            logger_(0),
+            enable_packet_logging_(false),
+        	frame_timeout_ms_(1000),
+			frames_timedout_(0)
         {
-            // Retrieve the packet logger instance
-            packet_logger_ = Logger::getLogger("FR.PacketLogger");
         };
 
         virtual ~FrameDecoder() = 0;
+
+        virtual void init(LoggerPtr& logger, bool enable_packet_logging=false, unsigned int frame_timeout_ms=1000)
+        {
+            logger_ = logger;
+            enable_packet_logging_ = enable_packet_logging;
+            // Retrieve the packet logger instance
+            packet_logger_ = Logger::getLogger("FR.PacketLogger");
+            // Setup frame timeout
+        	frame_timeout_ms_ = frame_timeout_ms;
+        };
 
         void register_buffer_manager(OdinData::SharedBufferManagerPtr buffer_manager)
         {
@@ -110,6 +120,9 @@ namespace FrameReceiver
 
         std::queue<int>    empty_buffer_queue_;
         std::map<uint32_t, int> frame_buffer_map_;
+
+        unsigned int frame_timeout_ms_;
+        unsigned int frames_timedout_;
     };
 
     inline FrameDecoder::~FrameDecoder() {};

--- a/frameReceiver/include/FrameReceiverApp.h
+++ b/frameReceiver/include/FrameReceiverApp.h
@@ -33,9 +33,8 @@ using namespace log4cxx::helpers;
 #include "FrameReceiverConfig.h"
 #include "FrameReceiverRxThread.h"
 #include "FrameDecoder.h"
-#include "PercivalEmulatorFrameDecoder.h"
-#include "ExcaliburFrameDecoder.h"
 #include "OdinDataException.h"
+#include "ClassLoader.h"
 
 using namespace OdinData;
 

--- a/frameReceiver/include/PercivalEmulatorFrameDecoder.h
+++ b/frameReceiver/include/PercivalEmulatorFrameDecoder.h
@@ -21,8 +21,10 @@ namespace FrameReceiver
     {
     public:
 
-        PercivalEmulatorFrameDecoder(LoggerPtr& logger, bool ebable_packet_logging=false, unsigned int frame_timeout_ms=1000);
+        PercivalEmulatorFrameDecoder();
         ~PercivalEmulatorFrameDecoder();
+
+        void init(LoggerPtr& logger, bool enable_packet_logging=false, unsigned int frame_timeout_ms=1000);
 
         const size_t get_frame_buffer_size(void) const;
         const size_t get_frame_header_size(void) const;
@@ -66,8 +68,6 @@ namespace FrameReceiver
 
         bool dropping_frame_data_;
 
-        unsigned int frame_timeout_ms_;
-        unsigned int frames_timedout_;
     };
 
 } // namespace FrameReceiver

--- a/frameReceiver/src/CMakeLists.txt
+++ b/frameReceiver/src/CMakeLists.txt
@@ -1,11 +1,19 @@
 
 set(CMAKE_INCLUDE_CURRENT_DIR on)
+ADD_DEFINITIONS(-DBUILD_DIR="${CMAKE_BINARY_DIR}")
 
 include_directories(${FRAMERECEIVER_DIR}/include ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
 
-file(GLOB APP_SOURCES *.cpp)
+file(GLOB APP_SOURCES appMain.cpp FrameReceiverApp.cpp FrameReceiverRxThread.cpp)
 
 add_executable(frameReceiver ${APP_SOURCES})
 
 target_link_libraries(frameReceiver ${COMMON_LIBRARY} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
 
+# Add library for Percival frame decoder
+add_library(PercivalEmulatorFrameDecoder SHARED PercivalEmulatorFrameDecoder.cpp PercivalEmulatorFrameDecoderLib.cpp)
+target_link_libraries(PercivalEmulatorFrameDecoder ${COMMON_LIBRARY} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})
+
+# Add library for Excalibur frame decoder
+add_library(ExcaliburFrameDecoder SHARED ExcaliburFrameDecoder.cpp ExcaliburFrameDecoderLib.cpp)
+target_link_libraries(ExcaliburFrameDecoder ${COMMON_LIBRARY} ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES} ${ZEROMQ_LIBRARIES})

--- a/frameReceiver/src/ExcaliburFrameDecoder.cpp
+++ b/frameReceiver/src/ExcaliburFrameDecoder.cpp
@@ -14,19 +14,25 @@
 
 using namespace FrameReceiver;
 
-ExcaliburFrameDecoder::ExcaliburFrameDecoder(LoggerPtr& logger,
-        bool enable_packet_logging, unsigned int frame_timeout_ms) :
-        FrameDecoder(logger, enable_packet_logging),
+ExcaliburFrameDecoder::ExcaliburFrameDecoder() :
+        FrameDecoder(),
 		current_frame_seen_(-1),
 		current_frame_buffer_id_(-1),
 		current_frame_buffer_(0),
 		current_frame_header_(0),
-		dropping_frame_data_(false),
-		frame_timeout_ms_(frame_timeout_ms),
-		frames_timedout_(0)
+		dropping_frame_data_(false)
 {
     current_packet_header_.reset(new uint8_t[sizeof(Excalibur::PacketHeader)]);
     dropped_frame_buffer_.reset(new uint8_t[Excalibur::total_frame_size]);
+}
+
+ExcaliburFrameDecoder::~ExcaliburFrameDecoder()
+{
+}
+
+void ExcaliburFrameDecoder::init(LoggerPtr& logger, bool enable_packet_logging, unsigned int frame_timeout_ms)
+{
+	FrameDecoder::init(logger, enable_packet_logging, frame_timeout_ms);
 
     if (enable_packet_logging_) {
         LOG4CXX_INFO(packet_logger_, "PktHdr: SourceAddress");
@@ -37,10 +43,6 @@ ExcaliburFrameDecoder::ExcaliburFrameDecoder(LoggerPtr& logger,
         LOG4CXX_INFO(packet_logger_, "PktHdr: |               |     |      |           |");
         LOG4CXX_INFO(packet_logger_, "PktHdr: |-------------- |---- |----  |---------- |----------");
     }
-}
-
-ExcaliburFrameDecoder::~ExcaliburFrameDecoder()
-{
 }
 
 const size_t ExcaliburFrameDecoder::get_frame_buffer_size(void) const

--- a/frameReceiver/src/ExcaliburFrameDecoderLib.cpp
+++ b/frameReceiver/src/ExcaliburFrameDecoderLib.cpp
@@ -1,0 +1,20 @@
+/*
+ * ExcaliburFrameDecoderLib.cpp
+ *
+ *  Created on: 7 Mar 2017
+ *      Author: gnx91527
+ */
+
+#include "ExcaliburFrameDecoder.h"
+#include "ClassLoader.h"
+
+namespace FrameReceiver
+{
+    /**
+     * Registration of this decoder through the ClassLoader.  This macro
+     * registers the class without needing to worry about name mangling
+     */
+    REGISTER(FrameDecoder, ExcaliburFrameDecoder, "ExcaliburFrameDecoder");
+
+} // namespace FrameReceiver
+

--- a/frameReceiver/src/PercivalEmulatorFrameDecoder.cpp
+++ b/frameReceiver/src/PercivalEmulatorFrameDecoder.cpp
@@ -14,19 +14,25 @@
 
 using namespace FrameReceiver;
 
-PercivalEmulatorFrameDecoder::PercivalEmulatorFrameDecoder(LoggerPtr& logger,
-        bool enable_packet_logging, unsigned int frame_timeout_ms) :
-        FrameDecoder(logger, enable_packet_logging),
+PercivalEmulatorFrameDecoder::PercivalEmulatorFrameDecoder() :
+        FrameDecoder(),
 		current_frame_seen_(-1),
 		current_frame_buffer_id_(-1),
 		current_frame_buffer_(0),
 		current_frame_header_(0),
-		dropping_frame_data_(false),
-		frame_timeout_ms_(frame_timeout_ms),
-		frames_timedout_(0)
+		dropping_frame_data_(false)
 {
     current_packet_header_.reset(new uint8_t[sizeof(PercivalEmulator::PacketHeader)]);
     dropped_frame_buffer_.reset(new uint8_t[PercivalEmulator::total_frame_size]);
+}
+
+PercivalEmulatorFrameDecoder::~PercivalEmulatorFrameDecoder()
+{
+}
+
+void PercivalEmulatorFrameDecoder::init(LoggerPtr& logger, bool enable_packet_logging, unsigned int frame_timeout_ms)
+{
+	FrameDecoder::init(logger, enable_packet_logging, frame_timeout_ms);
 
     if (enable_packet_logging_) {
         LOG4CXX_INFO(packet_logger_, "PktHdr: SourceAddress");
@@ -39,10 +45,6 @@ PercivalEmulatorFrameDecoder::PercivalEmulatorFrameDecoder(LoggerPtr& logger,
         LOG4CXX_INFO(packet_logger_, "PktHdr: |               |     |      |  |  |           |       Info [14 Bytes]");
         LOG4CXX_INFO(packet_logger_, "PktHdr: |               |     |      |  |  |           |       |");
     }
-}
-
-PercivalEmulatorFrameDecoder::~PercivalEmulatorFrameDecoder()
-{
 }
 
 const size_t PercivalEmulatorFrameDecoder::get_frame_buffer_size(void) const

--- a/frameReceiver/src/PercivalEmulatorFrameDecoderLib.cpp
+++ b/frameReceiver/src/PercivalEmulatorFrameDecoderLib.cpp
@@ -1,0 +1,23 @@
+/*
+ * PercivalEmulatorFrameDecoderLib.cpp
+ *
+ *  Created on: 7 Mar 2017
+ *      Author: gnx91527
+ */
+
+#include "PercivalEmulatorFrameDecoder.h"
+#include "ClassLoader.h"
+
+namespace FrameReceiver
+{
+	/**
+	 * Registration of this decoder through the ClassLoader.  This macro
+	 * registers the class without needing to worry about name mangling
+	 */
+	REGISTER(FrameDecoder, PercivalEmulatorFrameDecoder, "PercivalEmulatorFrameDecoder");
+
+} // namespace FrameReceiver
+
+
+
+

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 set(CMAKE_INCLUDE_CURRENT_DIR on)
 ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
+ADD_DEFINITIONS(-DBUILD_DIR="${CMAKE_BINARY_DIR}")
 
 include_directories(${FRAMERECEIVER_DIR}/include ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
 
@@ -10,7 +11,9 @@ file(GLOB TEST_SOURCES *.cpp)
 # Build list of main project source files from src dir but exclude application main
 file(GLOB APP_SOURCES ${FRAMERECEIVER_DIR}/src/*.cpp)
 file(GLOB APP_MAIN_SOURCE ${FRAMERECEIVER_DIR}/src/appMain.cpp)
+file(GLOB LIB_SOURCES ${FRAMERECEIVER_DIR}/src/*Lib.cpp)
 list(REMOVE_ITEM APP_SOURCES ${APP_MAIN_SOURCE})
+list(REMOVE_ITEM APP_SOURCES ${LIB_SOURCES})
 
 # Add test and project source files to executable
 add_executable(frameReceiverTest ${TEST_SOURCES} ${APP_SOURCES})

--- a/test/unittest/FrameDecoderUnitTest.cpp
+++ b/test/unittest/FrameDecoderUnitTest.cpp
@@ -29,7 +29,8 @@ BOOST_FIXTURE_TEST_SUITE(FrameDecoderUnitTest, FrameDecoderTestFixture);
 
 BOOST_AUTO_TEST_CASE( PercivalEmulatorDecoderTest )
 {
-    boost::shared_ptr<FrameReceiver::FrameDecoder> decoder(new FrameReceiver::PercivalEmulatorFrameDecoder(logger));
+    boost::shared_ptr<FrameReceiver::FrameDecoder> decoder(new FrameReceiver::PercivalEmulatorFrameDecoder());
+    decoder->init(logger);
 
     BOOST_TEST_MESSAGE("Emulator buffer size is specified as " << decoder->get_frame_buffer_size());
     BOOST_TEST_MESSAGE("Emulator frame header size is specified as " << decoder->get_frame_header_size());

--- a/test/unittest/FrameReceiverRxThreadUnitTest.cpp
+++ b/test/unittest/FrameReceiverRxThreadUnitTest.cpp
@@ -48,9 +48,10 @@ public:
         rx_channel(ZMQ_PAIR),
         logger(log4cxx::Logger::getLogger("FrameReceiverRxThreadUnitTest")),
         proxy(config),
-        frame_decoder(new FrameReceiver::PercivalEmulatorFrameDecoder(logger)),
+        frame_decoder(new FrameReceiver::PercivalEmulatorFrameDecoder()),
         buffer_manager(new OdinData::SharedBufferManager("TestSharedBuffer", 10000, 1000))
     {
+    	frame_decoder->init(logger);
 
         BOOST_TEST_MESSAGE("Setup test fixture");
 


### PR DESCRIPTION
Updated odin-data frame receiver to work with the classloader.  Updated percival and excalibur classes to build into their own shared libraries and then updated the application to load the appropriate one.  There is still some specific code in the receiver application class, mostly to do with reading configuration but these changes will allow a new third party project to build its own decoder library and in the future work with odin-data.

Please review and ask for any clarification...